### PR TITLE
[BEAM-8960]: Add an option for user to opt out of using insert id for Bigquery streaming insert.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1643,6 +1643,7 @@ public class BigQueryIO {
         .setExtendedErrorInfo(false)
         .setSkipInvalidRows(false)
         .setIgnoreUnknownValues(false)
+        .setIgnoreInsertIds(false)
         .setMaxFilesPerPartition(BatchLoads.DEFAULT_MAX_FILES_PER_PARTITION)
         .setMaxBytesPerPartition(BatchLoads.DEFAULT_MAX_BYTES_PER_PARTITION)
         .setOptimizeWrites(false)
@@ -1774,6 +1775,8 @@ public class BigQueryIO {
 
     abstract Boolean getIgnoreUnknownValues();
 
+    abstract Boolean getIgnoreInsertIds();
+
     @Nullable
     abstract String getKmsKey();
 
@@ -1845,6 +1848,8 @@ public class BigQueryIO {
       abstract Builder<T> setSkipInvalidRows(Boolean skipInvalidRows);
 
       abstract Builder<T> setIgnoreUnknownValues(Boolean ignoreUnknownValues);
+
+      abstract Builder<T> setIgnoreInsertIds(Boolean ignoreInsertIds);
 
       abstract Builder<T> setKmsKey(String kmsKey);
 
@@ -2241,6 +2246,12 @@ public class BigQueryIO {
       return toBuilder().setIgnoreUnknownValues(true).build();
     }
 
+    /**
+     * Performs streaming insert without insert id. Insert id is used to offer best effort insert deduplication.
+     * Default is false, which always inserts with insert id.
+     */
+    public Write<T> ignoreInsertIds() { return toBuilder().setIgnoreInsertIds(true).build(); }
+
     public Write<T> withKmsKey(String kmsKey) {
       return toBuilder().setKmsKey(kmsKey).build();
     }
@@ -2600,6 +2611,7 @@ public class BigQueryIO {
                 .withExtendedErrorInfo(getExtendedErrorInfo())
                 .withSkipInvalidRows(getSkipInvalidRows())
                 .withIgnoreUnknownValues(getIgnoreUnknownValues())
+                .withIgnoreInsertIds(getIgnoreInsertIds())
                 .withKmsKey(getKmsKey());
         return input.apply(streamingInserts);
       } else {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -158,7 +158,8 @@ public interface BigQueryServices extends Serializable {
         List<ValueInSingleWindow<T>> failedInserts,
         ErrorContainer<T> errorContainer,
         boolean skipInvalidRows,
-        boolean ignoreUnknownValues)
+        boolean ignoreUnknownValues,
+        boolean ignoreInsertIds)
         throws IOException, InterruptedException;
 
     /** Patch BigQuery {@link Table} description. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -713,7 +713,8 @@ class BigQueryServicesImpl implements BigQueryServices {
         List<ValueInSingleWindow<T>> failedInserts,
         ErrorContainer<T> errorContainer,
         boolean skipInvalidRows,
-        boolean ignoreUnkownValues)
+        boolean ignoreUnkownValues,
+        boolean ignoreInsertIds)
         throws IOException, InterruptedException {
       checkNotNull(ref, "ref");
       if (executor == null) {
@@ -733,7 +734,10 @@ class BigQueryServicesImpl implements BigQueryServices {
       // These lists contain the rows to publish. Initially the contain the entire list.
       // If there are failures, they will contain only the failed rows to be retried.
       List<ValueInSingleWindow<TableRow>> rowsToPublish = rowList;
-      List<String> idsToPublish = insertIdList;
+      List<String> idsToPublish = null;
+      if (!ignoreInsertIds) {
+        idsToPublish = insertIdList;
+      }
       while (true) {
         List<ValueInSingleWindow<TableRow>> retryRows = new ArrayList<>();
         List<String> retryIds = (idsToPublish != null) ? new ArrayList<>() : null;
@@ -866,7 +870,8 @@ class BigQueryServicesImpl implements BigQueryServices {
         List<ValueInSingleWindow<T>> failedInserts,
         ErrorContainer<T> errorContainer,
         boolean skipInvalidRows,
-        boolean ignoreUnknownValues)
+        boolean ignoreUnknownValues,
+        boolean ignoreInsertIds)
         throws IOException, InterruptedException {
       return insertAll(
           ref,
@@ -878,7 +883,8 @@ class BigQueryServicesImpl implements BigQueryServices {
           failedInserts,
           errorContainer,
           skipInvalidRows,
-          ignoreUnknownValues);
+          ignoreUnknownValues,
+          ignoreInsertIds);
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
@@ -38,6 +38,7 @@ public class StreamingInserts<DestinationT, ElementT>
   private boolean extendedErrorInfo;
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
+  private final boolean ignoreInsertIds;
   private final String kmsKey;
   private final Coder<ElementT> elementCoder;
   private final SerializableFunction<ElementT, TableRow> toTableRow;
@@ -56,6 +57,7 @@ public class StreamingInserts<DestinationT, ElementT>
         false,
         false,
         false,
+        false,
         elementCoder,
         toTableRow,
         null);
@@ -70,6 +72,7 @@ public class StreamingInserts<DestinationT, ElementT>
       boolean extendedErrorInfo,
       boolean skipInvalidRows,
       boolean ignoreUnknownValues,
+      boolean ignoreInsertIds,
       Coder<ElementT> elementCoder,
       SerializableFunction<ElementT, TableRow> toTableRow,
       String kmsKey) {
@@ -80,6 +83,7 @@ public class StreamingInserts<DestinationT, ElementT>
     this.extendedErrorInfo = extendedErrorInfo;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.ignoreInsertIds = ignoreInsertIds;
     this.elementCoder = elementCoder;
     this.toTableRow = toTableRow;
     this.kmsKey = kmsKey;
@@ -96,6 +100,7 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
@@ -111,6 +116,7 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
@@ -125,6 +131,7 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
@@ -139,9 +146,25 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
+  }
+
+  StreamingInserts<DestinationT, ElementT> withIgnoreInsertIds(boolean ignoreInsertIds) {
+    return new StreamingInserts<>(
+            createDisposition,
+            dynamicDestinations,
+            bigQueryServices,
+            retryPolicy,
+            extendedErrorInfo,
+            skipInvalidRows,
+            ignoreUnknownValues,
+            ignoreInsertIds,
+            elementCoder,
+            toTableRow,
+            kmsKey);
   }
 
   StreamingInserts<DestinationT, ElementT> withKmsKey(String kmsKey) {
@@ -153,6 +176,7 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
@@ -167,6 +191,7 @@ public class StreamingInserts<DestinationT, ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow,
         kmsKey);
@@ -188,6 +213,7 @@ public class StreamingInserts<DestinationT, ElementT>
             .withExtendedErrorInfo(extendedErrorInfo)
             .withSkipInvalidRows(skipInvalidRows)
             .withIgnoreUnknownValues(ignoreUnknownValues)
+            .withIgnoreInsertIds(ignoreInsertIds)
             .withElementCoder(elementCoder)
             .withToTableRow(toTableRow));
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteFn.java
@@ -49,6 +49,7 @@ class StreamingWriteFn<ErrorT, ElementT>
   private final ErrorContainer<ErrorT> errorContainer;
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
+  private final boolean ignoreInsertIds;
   private final SerializableFunction<ElementT, TableRow> toTableRow;
 
   /** JsonTableRows to accumulate BigQuery rows in order to batch writes. */
@@ -67,6 +68,7 @@ class StreamingWriteFn<ErrorT, ElementT>
       ErrorContainer<ErrorT> errorContainer,
       boolean skipInvalidRows,
       boolean ignoreUnknownValues,
+      boolean ignoreInsertIds,
       SerializableFunction<ElementT, TableRow> toTableRow) {
     this.bqServices = bqServices;
     this.retryPolicy = retryPolicy;
@@ -74,6 +76,7 @@ class StreamingWriteFn<ErrorT, ElementT>
     this.errorContainer = errorContainer;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.ignoreInsertIds = ignoreInsertIds;
     this.toTableRow = toTableRow;
   }
 
@@ -145,7 +148,8 @@ class StreamingWriteFn<ErrorT, ElementT>
                     failedInserts,
                     errorContainer,
                     skipInvalidRows,
-                    ignoreUnknownValues);
+                    ignoreUnknownValues,
+                    ignoreInsertIds);
         byteCounter.inc(totalBytes);
       } catch (IOException e) {
         throw new RuntimeException(e);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -53,6 +53,7 @@ public class StreamingWriteTables<ElementT>
   private static final String FAILED_INSERTS_TAG_ID = "failedInserts";
   private final boolean skipInvalidRows;
   private final boolean ignoreUnknownValues;
+  private final boolean ignoreInsertIds;
   private final Coder<ElementT> elementCoder;
   private final SerializableFunction<ElementT, TableRow> toTableRow;
 
@@ -63,6 +64,7 @@ public class StreamingWriteTables<ElementT>
         false, // extendedErrorInfo
         false, // skipInvalidRows
         false, // ignoreUnknownValues
+        false, // ignoreInsertIds
         null, // elementCoder
         null); // toTableRow
   }
@@ -73,6 +75,7 @@ public class StreamingWriteTables<ElementT>
       boolean extendedErrorInfo,
       boolean skipInvalidRows,
       boolean ignoreUnknownValues,
+      boolean ignoreInsertIds,
       Coder<ElementT> elementCoder,
       SerializableFunction<ElementT, TableRow> toTableRow) {
     this.bigQueryServices = bigQueryServices;
@@ -80,6 +83,7 @@ public class StreamingWriteTables<ElementT>
     this.extendedErrorInfo = extendedErrorInfo;
     this.skipInvalidRows = skipInvalidRows;
     this.ignoreUnknownValues = ignoreUnknownValues;
+    this.ignoreInsertIds = ignoreInsertIds;
     this.elementCoder = elementCoder;
     this.toTableRow = toTableRow;
   }
@@ -91,6 +95,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -102,6 +107,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -113,6 +119,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -124,6 +131,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -135,8 +143,21 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
+  }
+
+  StreamingWriteTables<ElementT> withIgnoreInsertIds(boolean ignoreInsertIds) {
+    return new StreamingWriteTables<>(
+            bigQueryServices,
+            retryPolicy,
+            extendedErrorInfo,
+            skipInvalidRows,
+            ignoreUnknownValues,
+            ignoreInsertIds,
+            elementCoder,
+            toTableRow);
   }
 
   StreamingWriteTables<ElementT> withElementCoder(Coder<ElementT> elementCoder) {
@@ -146,6 +167,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -158,6 +180,7 @@ public class StreamingWriteTables<ElementT>
         extendedErrorInfo,
         skipInvalidRows,
         ignoreUnknownValues,
+        ignoreInsertIds,
         elementCoder,
         toTableRow);
   }
@@ -240,6 +263,7 @@ public class StreamingWriteTables<ElementT>
                             errorContainer,
                             skipInvalidRows,
                             ignoreUnknownValues,
+                            ignoreInsertIds,
                             toTableRow))
                     .withOutputTags(mainOutputTag, TupleTagList.of(failedInsertsTag)));
     PCollection<T> failedInserts = tuple.get(failedInsertsTag);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/TableContainer.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/testing/TableContainer.java
@@ -39,7 +39,9 @@ class TableContainer {
 
   long addRow(TableRow row, String id) {
     rows.add(row);
-    ids.add(id);
+    if (id != null) {
+      ids.add(id);
+    }
     long rowSize = row.toString().length();
     Long tableSize = table.getNumBytes();
     if (tableSize == null) {
@@ -56,5 +58,9 @@ class TableContainer {
 
   List<TableRow> getRows() {
     return rows;
+  }
+
+  List<String> getIds() {
+    return ids;
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -684,6 +684,35 @@ public class BigQueryIOWriteTest implements Serializable {
     p.run();
   }
 
+  @Test
+  public void testWriteWithoutInsertId() throws Exception {
+    p.apply(
+            Create.of(
+                    new TableRow().set("name", "a").set("number", 1),
+                    new TableRow().set("name", "b").set("number", 2),
+                    new TableRow().set("name", "c").set("number", 3))
+                    .withCoder(TableRowJsonCoder.of()))
+            .apply(
+                    BigQueryIO.writeTableRows()
+                            .to("project-id:dataset-id.table-id")
+                            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
+                            .withMethod(BigQueryIO.Write.Method.STREAMING_INSERTS)
+                            .withSchema(
+                                    new TableSchema()
+                                            .setFields(
+                                                    ImmutableList.of(
+                                                            new TableFieldSchema().setName("name").setType("STRING"),
+                                                            new TableFieldSchema().setName("number").setType("INTEGER"))))
+                            .withTestServices(fakeBqServices)
+                            .ignoreInsertIds()
+                            .withoutValidation());
+    p.run();
+    // Only row1 and row3 were successfully inserted.
+    assertThat(
+            fakeDatasetService.getAllIds("project-id", "dataset-id", "table-id"),
+            containsInAnyOrder());
+  }
+
   @AutoValue
   abstract static class InputRecord implements Serializable {
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -517,6 +517,7 @@ public class BigQueryServicesImplTest {
         null,
         null,
         false,
+        false,
         false);
     verify(response, times(2)).getStatusCode();
     verify(response, times(2)).getContent();
@@ -550,6 +551,7 @@ public class BigQueryServicesImplTest {
         InsertRetryPolicy.alwaysRetry(),
         null,
         null,
+        false,
         false,
         false);
     verify(response, times(2)).getStatusCode();
@@ -601,6 +603,7 @@ public class BigQueryServicesImplTest {
         null,
         null,
         false,
+        false,
         false);
     verify(response, times(2)).getStatusCode();
     verify(response, times(2)).getContent();
@@ -645,6 +648,7 @@ public class BigQueryServicesImplTest {
           InsertRetryPolicy.alwaysRetry(),
           null,
           null,
+          false,
           false,
           false);
       fail();
@@ -692,6 +696,7 @@ public class BigQueryServicesImplTest {
         InsertRetryPolicy.alwaysRetry(),
         null,
         null,
+        false,
         false,
         false);
     verify(response, times(2)).getStatusCode();
@@ -761,17 +766,18 @@ public class BigQueryServicesImplTest {
         failedInserts,
         ErrorContainer.TABLE_ROW_ERROR_CONTAINER,
         false,
+        false,
         false);
     assertEquals(1, failedInserts.size());
     expectedLogs.verifyInfo("Retrying 1 failed inserts to BigQuery");
   }
 
   /**
-   * Tests that {@link DatasetServiceImpl#insertAll} respects the skipInvalidRows and
-   * ignoreUnknownValues parameters.
+   * Tests that {@link DatasetServiceImpl#insertAll} respects the skipInvalidRows,
+   * ignoreUnknownValues and ignoreInsertIds parameters.
    */
   @Test
-  public void testSkipInvalidRowsIgnoreUnknownValuesStreaming()
+  public void testSkipInvalidRowsIgnoreUnknownIgnoreInsertIdsValuesStreaming()
       throws InterruptedException, IOException {
     TableReference ref =
         new TableReference().setProjectId("project").setDatasetId("dataset").setTableId("table");
@@ -790,7 +796,7 @@ public class BigQueryServicesImplTest {
     DatasetServiceImpl dataService =
         new DatasetServiceImpl(bigquery, PipelineOptionsFactory.create());
 
-    // First, test with both flags disabled
+    // First, test with all flags disabled
     dataService.insertAll(
         ref,
         rows,
@@ -801,6 +807,7 @@ public class BigQueryServicesImplTest {
         Lists.newArrayList(),
         ErrorContainer.TABLE_ROW_ERROR_CONTAINER,
         false,
+        false,
         false);
 
     TableDataInsertAllRequest parsedRequest =
@@ -809,7 +816,7 @@ public class BigQueryServicesImplTest {
     assertFalse(parsedRequest.getSkipInvalidRows());
     assertFalse(parsedRequest.getIgnoreUnknownValues());
 
-    // Then with both enabled
+    // Then with all enabled
     dataService.insertAll(
         ref,
         rows,
@@ -820,12 +827,15 @@ public class BigQueryServicesImplTest {
         Lists.newArrayList(),
         ErrorContainer.TABLE_ROW_ERROR_CONTAINER,
         true,
+        true,
         true);
 
     parsedRequest = fromString(request.getContentAsString(), TableDataInsertAllRequest.class);
 
     assertTrue(parsedRequest.getSkipInvalidRows());
     assertTrue(parsedRequest.getIgnoreUnknownValues());
+    assertNull(parsedRequest.getRows().get(0).getInsertId());
+    assertNull(parsedRequest.getRows().get(1).getInsertId());
   }
 
   /** A helper to convert a string response back to a {@link GenericJson} subclass. */
@@ -1002,6 +1012,7 @@ public class BigQueryServicesImplTest {
         failedInserts,
         ErrorContainer.TABLE_ROW_ERROR_CONTAINER,
         false,
+        false,
         false);
 
     assertThat(failedInserts, is(rows));
@@ -1055,6 +1066,7 @@ public class BigQueryServicesImplTest {
         InsertRetryPolicy.neverRetry(),
         failedInserts,
         ErrorContainer.BIG_QUERY_INSERT_ERROR_ERROR_CONTAINER,
+        false,
         false,
         false);
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
@@ -205,7 +205,7 @@ public class BigQueryUtilTest {
     try {
       totalBytes =
           datasetService.insertAll(
-              ref, rows, ids, InsertRetryPolicy.alwaysRetry(), null, null, false, false);
+              ref, rows, ids, InsertRetryPolicy.alwaysRetry(), null, null, false, false, false);
     } finally {
       verifyInsertAll(5);
       // Each of the 25 rows is 23 bytes: "{f=[{v=foo}, {v=1234}]}"


### PR DESCRIPTION
…nector.

Expose an option so that user can opt out of using insert id while streaming into BigQuery.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
